### PR TITLE
Optionally encrypt password

### DIFF
--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -42,7 +42,7 @@ class MakeUser extends Command {
         $password = $this->secret("What is the new user's password? (blank generates a random one)", str_random(32));
         $sendReset = $this->confirm('Do you want to send a password reset email?');
 
-        if (!$this->option('plaintext')) {
+        if (!$this->option('plaintext')) { // optional
             bcrypt($password);
         }
 

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -7,13 +7,14 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Password;
 use Dyrynda\Artisan\Exceptions\MakeUserException;
 
-class MakeUser extends Command {
+class MakeUser extends Command 
+{
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'make:user {--p|plaintext}';
+    protected $signature = 'make:user';
 
     /**
      * The console command description.
@@ -36,14 +37,16 @@ class MakeUser extends Command {
      *
      * @return void
      */
-    public function handle() {
+    public function handle() 
+    {
         $email = $this->ask("What is the new user's email address?");
         $name = $this->ask("What is the new user's name?") ?: '';
         $password = $this->secret("What is the new user's password? (blank generates a random one)", str_random(32));
+        $encrypt = $this->confirm('Should the password be encrypted?', true);
         $sendReset = $this->confirm('Do you want to send a password reset email?');
 
-        if (!$this->option('plaintext')) { // optional
-            bcrypt($password);
+        if ($encrypt) {
+            $password = bcrypt($password);
         }
 
         while ($custom = $this->ask('Do you have any custom user fields to add? Field=Value (blank continues)', false)) {
@@ -87,7 +90,8 @@ class MakeUser extends Command {
      *
      * @throws \Dyrynda\Artisan\Exceptions\MakeUserException
      */
-    private function validateEmail($email) {
+    private function validateEmail($email) 
+    {
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             throw MakeUserException::invalidEmail($email);
         }

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -42,7 +42,7 @@ class MakeUser extends Command {
         $password = $this->secret("What is the new user's password? (blank generates a random one)", str_random(32));
         $sendReset = $this->confirm('Do you want to send a password reset email?');
 
-        if (!$this->option('password')) {
+        if (!$this->option('plaintext')) {
             bcrypt($password);
         }
 

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -13,7 +13,7 @@ class MakeUser extends Command {
      *
      * @var string
      */
-    protected $signature = 'make:user {--p|plaintext}';
+    protected $signature = 'make:user';
 
     /**
      * The console command description.
@@ -40,10 +40,11 @@ class MakeUser extends Command {
         $email = $this->ask("What is the new user's email address?");
         $name = $this->ask("What is the new user's name?") ?: '';
         $password = $this->secret("What is the new user's password? (blank generates a random one)", str_random(32));
+        $encrypt = $this->confirm('Should the password be encrypted?', true);
         $sendReset = $this->confirm('Do you want to send a password reset email?');
 
-        if (!$this->option('plaintext')) {
-            bcrypt($password);
+        if ($encrypt) {
+            $password = bcrypt($password);
         }
 
         while ($custom = $this->ask('Do you have any custom user fields to add? Field=Value (blank continues)', false)) {

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Password;
 use Dyrynda\Artisan\Exceptions\MakeUserException;
 
-class MakeUser extends Command 
+class MakeUser extends Command
 {
     /**
      * The name and signature of the console command.
@@ -37,7 +37,7 @@ class MakeUser extends Command
      *
      * @return void
      */
-    public function handle() 
+    public function handle()
     {
         $email = $this->ask("What is the new user's email address?");
         $name = $this->ask("What is the new user's name?") ?: '';
@@ -50,7 +50,7 @@ class MakeUser extends Command
         }
 
         while ($custom = $this->ask('Do you have any custom user fields to add? Field=Value (blank continues)', false)) {
-            list($key, $value) = explode('=', $custom);
+            [$key, $value] = explode('=', $custom);
             $this->customFields[$key] = value($value);
         }
 
@@ -90,9 +90,9 @@ class MakeUser extends Command
      *
      * @throws \Dyrynda\Artisan\Exceptions\MakeUserException
      */
-    private function validateEmail($email) 
+    private function validateEmail($email)
     {
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
             throw MakeUserException::invalidEmail($email);
         }
 

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -7,14 +7,13 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Password;
 use Dyrynda\Artisan\Exceptions\MakeUserException;
 
-class MakeUser extends Command
-{
+class MakeUser extends Command {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'make:user';
+    protected $signature = 'make:user {--p|plaintext}';
 
     /**
      * The console command description.
@@ -37,12 +36,15 @@ class MakeUser extends Command
      *
      * @return void
      */
-    public function handle()
-    {
+    public function handle() {
         $email = $this->ask("What is the new user's email address?");
         $name = $this->ask("What is the new user's name?") ?: '';
-        $password = bcrypt($this->secret("What is the new user's password? (blank generates a random one)", str_random(32)));
+        $password = $this->secret("What is the new user's password? (blank generates a random one)", str_random(32));
         $sendReset = $this->confirm('Do you want to send a password reset email?');
+
+        if (!$this->option('password')) {
+            bcrypt($password);
+        }
 
         while ($custom = $this->ask('Do you have any custom user fields to add? Field=Value (blank continues)', false)) {
             list($key, $value) = explode('=', $custom);
@@ -85,9 +87,8 @@ class MakeUser extends Command
      *
      * @throws \Dyrynda\Artisan\Exceptions\MakeUserException
      */
-    private function validateEmail($email)
-    {
-        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    private function validateEmail($email) {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             throw MakeUserException::invalidEmail($email);
         }
 

--- a/tests/MakeUserTest.php
+++ b/tests/MakeUserTest.php
@@ -2,26 +2,25 @@
 
 namespace Tests;
 
-class MakeUserTest extends TestCase
-{
+class MakeUserTest extends TestCase {
     /** @test */
-    public function it_creates_a_new_user()
-    {
+    public function it_creates_a_new_user() {
         $this->artisan('make:user')
             ->expectsQuestion("What is the new user's email address?", 'user@example.com')
             ->expectsQuestion("What is the new user's name?", 'Test User')
             ->expectsQuestion("What is the new user's password? (blank generates a random one)", '')
+            ->expectsQuestion('Should the password be encrypted?', 'yes')
             ->expectsQuestion('Do you want to send a password reset email?', 'no')
             ->expectsQuestion('Do you have any custom user fields to add? Field=Value (blank continues)', '');
     }
 
     /** @test */
-    public function it_creates_a_new_user_with_additional_fields()
-    {
+    public function it_creates_a_new_user_with_additional_fields() {
         $this->artisan('make:user')
             ->expectsQuestion("What is the new user's email address?", 'user@example.com')
             ->expectsQuestion("What is the new user's name?", 'Test User')
             ->expectsQuestion("What is the new user's password? (blank generates a random one)", '')
+            ->expectsQuestion('Should the password be encrypted?', 'yes')
             ->expectsQuestion('Do you want to send a password reset email?', 'no')
             ->expectsQuestion('Do you have any custom user fields to add? Field=Value (blank continues)', 'field=value')
             ->expectsQuestion('Do you have any custom user fields to add? Field=Value (blank continues)', '');

--- a/tests/MakeUserTest.php
+++ b/tests/MakeUserTest.php
@@ -2,9 +2,10 @@
 
 namespace Tests;
 
-class MakeUserTest extends TestCase {
+class MakeUserTest extends TestCase
+{
     /** @test */
-    public function it_creates_a_new_user() 
+    public function it_creates_a_new_user()
     {
         $this->artisan('make:user')
             ->expectsQuestion("What is the new user's email address?", 'user@example.com')
@@ -16,7 +17,7 @@ class MakeUserTest extends TestCase {
     }
 
     /** @test */
-    public function it_creates_a_new_user_with_additional_fields() 
+    public function it_creates_a_new_user_with_additional_fields()
     {
         $this->artisan('make:user')
             ->expectsQuestion("What is the new user's email address?", 'user@example.com')

--- a/tests/MakeUserTest.php
+++ b/tests/MakeUserTest.php
@@ -4,7 +4,8 @@ namespace Tests;
 
 class MakeUserTest extends TestCase {
     /** @test */
-    public function it_creates_a_new_user() {
+    public function it_creates_a_new_user() 
+    {
         $this->artisan('make:user')
             ->expectsQuestion("What is the new user's email address?", 'user@example.com')
             ->expectsQuestion("What is the new user's name?", 'Test User')
@@ -15,7 +16,8 @@ class MakeUserTest extends TestCase {
     }
 
     /** @test */
-    public function it_creates_a_new_user_with_additional_fields() {
+    public function it_creates_a_new_user_with_additional_fields() 
+    {
         $this->artisan('make:user')
             ->expectsQuestion("What is the new user's email address?", 'user@example.com')
             ->expectsQuestion("What is the new user's name?", 'Test User')


### PR DESCRIPTION
I usually add something like this to my model:

```
public function setPasswordAttribute($password) {
        $this->attributes['password'] = Hash::make($password);
   }
```

Which means using this package would result in a password encrypted twice. I've added the ability to choose if the password is encrypted by the package with an option (-p).