### PR TITLE
Remove Laravel helpers dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "laravel/helpers": "^1.1.0",
         "illuminate/support": "^7.0",
         "illuminate/console": "^7.0",
         "illuminate/database": "^7.0",


### PR DESCRIPTION
Use of Laravel helpers was removed with 432da1d but the dependency was not removed.